### PR TITLE
Fix a flaky test.

### DIFF
--- a/src/test/java/com/github/underscore/ArraysTest.java
+++ b/src/test/java/com/github/underscore/ArraysTest.java
@@ -32,7 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -457,7 +457,7 @@ public class ArraysTest {
         assertEquals(
                 "[a, aa, cc, ccc]",
                 new U<>(asList("a", "aa", "cc", "ccc")).replace(null, "b").toString());
-        Set<Integer> set = new HashSet<>();
+        Set<Integer> set = new LinkedHashSet<>();
         set.addAll(U.range(7));
         assertEquals(
                 "[0, 1, 2, 100, 100, 100, 100]",


### PR DESCRIPTION
1. The test Failure:
- Run the test `com.github.underscore.ArraysTest.replace` with:
   `mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=com.github.underscore.ArraysTest#replace ` 
Here are the details of [NonDex](https://github.com/TestingResearchIllinois/NonDex).
- Get some failures:
`Failed tests:   replace(com.github.underscore.ArraysTest): expected:<[[0, 1, 2, 10]0, 100, 100, 100]> but was:<[[100, 2, 1, ]0, 100, 100, 100]>`

2. Why it fails:
- In `src/test/java/com/github/underscore/ArraysTest.java` : `Set<Integer> set = new HashSet<>();` , HashSet makes no guarantee about the iteration order. The specification about HashSet says that "It makes no guarantees as to the iteration order of the set; in particular, it does not guarantee that the order will remain constant over time".

3. Fix it:
- By changing HashSet into LinkedHashSet.
